### PR TITLE
Updated README.md to reflect `gradle>=6.8` requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Tool | Version |Source |
 |---|---|---|
 | Ghidra | `>= 10.1` | https://ghidra-sre.org |
 | Jep | `>= 4.0` | https://github.com/ninia/jep |
-| Gradle | `>= 6.0` | https://gradle.org/releases |
+| Gradle | `>= 6.8` | https://gradle.org/releases |
 | Python | `>= 3.7` | https://www.python.org/downloads |
 
 ## Python Virtual Environments


### PR DESCRIPTION
Just gone through the steps to install the tool using a clean Ubuntu 20.04 box and Python 3.8 and it works a charm bar an error when attempting to building with anything under `gradle 6.8`. 
