### PR TITLE
platform: support macOS and newer CPython

### DIFF
--- a/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
+++ b/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
@@ -85,36 +85,40 @@ public class GhidrathonInterpreter {
 	 * 
 	 * User must build and include native Jep library in the appropriate OS folder prior to
 	 * building this extension.
-	 * Requires os/win64/libjep.dll for Windows
-	 * Requires os/linux64/libjep.so for Linux
-	 * 
+	 * Requires os/win_<arch>/jep.dll for Windows
+	 * Requires os/mac_<arch>/jep.so for macOS
+	 * Requires os/linux_<arch>/libjep.so for Linux
+	 *
 	 * @throws JepException
 	 * @throws FileNotFoundException
 	 */
-	private void setJepNativeBinaryPath() throws JepException, FileNotFoundException {
-		
-		File nativeJep;
-		
-		try {
-			
-			nativeJep = Application.getOSFile(extname, "libjep.so");
-			
-		} catch (FileNotFoundException e) {
-			
-			// whoops try Windows
-			nativeJep = Application.getOSFile(extname, "jep.dll");
-
+	private void setJepNativeBinaryPath() throws JepException, FileNotFoundException
+	{
+		String[] nativeJepFileNames = {
+			"jep.dll",
+			"jep.so",
+			"libjep.so",
+		};
+		File nativeJep = null;
+		for (String nativeJepCandidate : nativeJepFileNames) {
+			try {
+				nativeJep = Application.getOSFile(extname, nativeJepCandidate);
+				break;
+			} catch (FileNotFoundException e) {
+				continue;
+			}
 		}
-		
+
+		if (nativeJep == null) {
+			throw new RuntimeException("Could not load any of following Jep native libraries: " + String.join(", ", nativeJepFileNames));
+		}
 		try {
-			
 			MainInterpreter.setJepLibraryPath(nativeJep.getAbsolutePath());
-			
 		} catch (IllegalStateException e) {
 			// library path has already been set elsewhere, we expect this to happen as Jep Maininterpreter
 			// thread exists forever once it's created
 		}
-		
+
 	}
 
 	

--- a/util/configure_jep_native_binaries.py
+++ b/util/configure_jep_native_binaries.py
@@ -6,22 +6,30 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-import subprocess
-import argparse
+import sys
+import os
+import glob
 import logging
 import shutil
-import glob
-import sys
 
 from pathlib import Path
 
-JEP_PY_FOLDER_NAME = "jep"
-JEP_OS_LIB_NAME_WINDOWS = "jep.dll"
-JEP_OS_LIB_NAME_LINUX = "libjep.so"
+JEP_PY_PACKAGE_NAME = "jep"
+JEP_OS_LIB_NAMES = {
+    "darwin": ("jep",    "so"),
+    "linux":  ("libjep", "so"),
+    "win32":  ("jep",    "dll"),
+    "cygwin": ("jep",    "dll"),
+}
 
 GHIDRA_JAVA_LIB_PATH = "lib"
-GHIDRA_OS_LIB_PATH_WINDOWS = "os/win_x86_64"
-GHIDRA_OS_LIB_PATH_LINUX = "os/linux_x86_64"
+GHIDRA_OS_LIB_PATH = "os"
+GHIDRA_OS_LIB_NAMES = {
+    "darwin": "mac_",
+    "linux":  "linux_",
+    "win32":  "win_",
+    "cygwin": "win_",
+}
 
 
 logger = logging.getLogger(__name__)
@@ -35,91 +43,109 @@ logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
 
-def find_jep_dir():
-    """attempt to locate Jep Python module directory
+def pathglob(root, pattern):
+    return [root / fn for fn in glob.glob(pattern, root_dir=str(root))]
 
-    we use naive method of checking each path in sys.path for a folder named jep
-    """
+def find_package_files(pkgname, pattern, fallback_dir = None):
+    """attempt to locate file(s) in package resources,
+    using importlib.metadata, pkg_resources and finally a naive search"""
+    try:
+        import importlib.metadata
+    except ImportError:
+        pass
+    else:
+        pkg_files = importlib.metadata.files(pkgname)
+        if pkg_files is not None:
+            return [f.locate() for f in pkg_files if f.match(pattern)]
+
+    try:
+        import pkg_resources
+    except ImportError:
+        pass
+    else:
+        dist = pkg_resources.get_distribution(pkgname)
+        if dist:
+            pkg_dir = Path(dist.location) / dist.key
+            return pathglob(pkg_dir, pattern)
+
     for path in sys.path:
-        jep_dir = Path(path) / JEP_PY_FOLDER_NAME
-        logger.debug("Checking if %s exists" % jep_dir)
-        if jep_dir.is_dir():
-            return jep_dir
-    return Path()
+        pkg_dir = Path(path) / pkgname
+        logger.debug("Checking if %s exists" % pkg_dir)
+        if pkg_dir.is_dir():
+            return pathglob(pkg_dir, pattern)
 
+    if fallback_dir:
+        return pathglob(fallback_dir, pattern)
+    raise ValueError("could not determine paths for package %s" % pkgname)
+
+
+def copyfile(src, dest):
+    logger.info("Copying %s to %s" % (src, dest))
+    shutil.copy(str(src), str(dest), follow_symlinks=True)
 
 def main(args):
     """ """
     if args.debug:
         logger.setLevel(logging.DEBUG)
-
-    if sys.platform in ("darwin",):
-        # we haven't tested MacOS enough to know for sure if we fully support it
-        logger.error("MacOS is not supported!")
-        return -1
-
-    if sys.platform in ("win32", "cygwin"):
-        logger.debug("Detected Windows OS")
-
-        os_lib_name = JEP_OS_LIB_NAME_WINDOWS
-        os_lib_path = Path(GHIDRA_OS_LIB_PATH_WINDOWS)
-    else:
-        logger.debug("Detected Linux OS")
-
-        os_lib_name = JEP_OS_LIB_NAME_LINUX
-        os_lib_path = Path(GHIDRA_OS_LIB_PATH_LINUX)
-
-    logger.info("Searching for Jep Python module directory")
-
     if args.path:
-        jep_dir = Path(args.path)
-        if not jep_dir.is_dir():
-            logger.error("Python module directory %s does not exist!" % args.path)
-            return -1
+        fallback_dir = Path(args.path)
     else:
-        jep_dir = find_jep_dir()
-        if not jep_dir:
-            logger.error("Could not find Jep Python module directory!")
-            return -1
+        fallback_dir = None
 
-    logger.info("Found Jep Python module directory at %s" % jep_dir)
-
-    try:
-        jep_java_lib_name = glob.glob(str(Path(jep_dir) / "*.jar"), recursive=False)[0]
-    except IndexError:
-        logger.error("Could not find Jep JAR file in directory %s" % jep_dir)
+    # Get Jep OS names
+    if sys.platform in JEP_OS_LIB_NAMES:
+        jep_os_lib_prefix, jep_os_lib_ext = JEP_OS_LIB_NAMES[sys.platform]
+    else:
+        logger.error("Unsupported platform: %s" % sys.platform)
         return -1
 
-    logger.info("Copying %s and %s to extension folders" % (os_lib_name, jep_java_lib_name))
+    # Get Ghidra names
+    ghidra_lib_path = Path(GHIDRA_JAVA_LIB_PATH)
+    if sys.platform in GHIDRA_OS_LIB_NAMES:
+        ghidra_os_lib_path = Path(GHIDRA_OS_LIB_PATH) / (GHIDRA_OS_LIB_NAMES[sys.platform] + os.uname().machine)
+    else:
+        logger.error("Unsupported platform: %s" % sys.platform)
+        return -1
 
+
+    logger.info("Searching for Jep JAR file")
+    jep_java_lib_paths = find_package_files(JEP_PY_PACKAGE_NAME, "*.jar", fallback_dir)
+    if not jep_java_lib_paths:
+        logger.error("Could not find Jep JAR file")
+        return -1
     # copy the Jep JAR file to the appropriate extension folder
-    logger.debug("Copying %s to %s" % (Path(jep_dir) / jep_java_lib_name, Path(GHIDRA_JAVA_LIB_PATH)))
-    try:
-        shutil.copy(Path(jep_dir) / jep_java_lib_name, Path(GHIDRA_JAVA_LIB_PATH), follow_symlinks=True)
-    except Exception as e:
-        logger.error("%s" % e)
-        return -1
+    copyfile(jep_java_lib_paths[0], ghidra_lib_path)
 
-    # copy the Jep OS-dependent file to the appopriate extension folder
-    logger.debug("Copying %s to %s" % (Path(jep_dir) / os_lib_name, os_lib_path))
-    try:
-        shutil.copy(Path(jep_dir) / os_lib_name, os_lib_path, follow_symlinks=True)
-    except Exception as e:
-        logger.error("%s" % e)
+
+    logger.info("Searching for Jep native library")
+    jep_os_lib_name = "%s.%s" % (jep_os_lib_prefix, jep_os_lib_ext)
+    jep_os_lib_paths = find_package_files(JEP_PY_PACKAGE_NAME, jep_os_lib_name, fallback_dir)
+    if not jep_os_lib_paths and sys.implementation.cache_tag:
+        jep_os_lib_impl_name = "%s%s.%s" % (
+            jep_os_lib_prefix,
+            '.%s-*' % sys.implementation.cache_tag,
+            jep_os_lib_ext
+        )
+        jep_os_lib_paths = find_package_files(JEP_PY_PACKAGE_NAME, jep_os_lib_impl_name, fallback_dir)
+    if not jep_os_lib_paths:
+        logger.error("Could not find Jep native library")
         return -1
+    # copy the Jep OS-dependent file to the appopriate extension folder
+    copyfile(jep_os_lib_paths[0], ghidra_os_lib_path / jep_os_lib_name)
+
 
     logger.info("Done")
-
     return 0
 
 
 if __name__ == "__main__":
     """ """
+    import argparse
     parser = argparse.ArgumentParser(
         description="Locate Jep module directory and copy necessary files to Ghidrathon extension directories."
     )
 
-    parser.add_argument("-p", "--path", type=str, help="Full path to Jep Python module directory")
+    parser.add_argument("-p", "--path", type=str, help="Fallback path to Jep Python module directory")
     parser.add_argument("-d", "--debug", action="store_true", help="Show debug messages")
 
     sys.exit(main(parser.parse_args()))


### PR DESCRIPTION
This PR fixes `util/configure_jep_native_libraries.py` to use the `importlib.metadata` and `pkg_resources` modules if available, before falling back to the old `sys.path` search. It also adds a fallback in case `(lib)jep.*` can't be found, trying again and interposing the implementation cache tag. Native libraries on macOS have been known to use this filename format (e.g.: `jep.cpython-310-darwin.so`). It then changes GhidrathonInterpreter to search for `jep.so` as well.

With this, I was able to get Ghidrathon to work under macOS with `gradle -PGHIDRA_INSTALL_DIR=/usr/local/Caskroom/ghidra/10.1.4-20220519/ghidra_10.1.4_PUBLIC -PPYTHON_BIN=python3 buildExtension`.