### PR TITLE
Add support for macOS (x86_64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Ghidrathon supports the following operating systems:
 
 * Linux
 * Windows
+* macOS (x86_64)
 
 ## Requirements
 

--- a/os/mac_x86_64/README.txt
+++ b/os/mac_x86_64/README.txt
@@ -1,0 +1,3 @@
+The "os/mac_x86_64" directory is intended to hold macOS native binaries
+which this module is dependent upon.   This directory may be eliminated for a specific 
+module if native binaries are not provided for the corresponding platform.

--- a/util/configure_jep_native_binaries.py
+++ b/util/configure_jep_native_binaries.py
@@ -18,10 +18,12 @@ from pathlib import Path
 JEP_PY_FOLDER_NAME = "jep"
 JEP_OS_LIB_NAME_WINDOWS = "jep.dll"
 JEP_OS_LIB_NAME_LINUX = "libjep.so"
+JEP_OS_LIB_NAME_DARWIN = "jep.cpython-%d%d-darwin.so" % sys.version_info[:2]
 
 GHIDRA_JAVA_LIB_PATH = "lib"
-GHIDRA_OS_LIB_PATH_WINDOWS = "os/win_x86_64"
-GHIDRA_OS_LIB_PATH_LINUX = "os/linux_x86_64"
+GHIDRA_OS_LIB_PATH_WINDOWS = "os/win_x86_64/jep.dll"
+GHIDRA_OS_LIB_PATH_LINUX = "os/linux_x86_64/libjep.so"
+GHIDRA_OS_LIB_PATH_DARWIN = "os/mac_x86_64/libjep.so"
 
 
 logger = logging.getLogger(__name__)
@@ -54,11 +56,11 @@ def main(args):
         logger.setLevel(logging.DEBUG)
 
     if sys.platform in ("darwin",):
-        # we haven't tested MacOS enough to know for sure if we fully support it
-        logger.error("MacOS is not supported!")
-        return -1
+        logger.debug("Detected macOS")
 
-    if sys.platform in ("win32", "cygwin"):
+        os_lib_name = JEP_OS_LIB_NAME_DARWIN
+        os_lib_path = Path(GHIDRA_OS_LIB_PATH_DARWIN)
+    elif sys.platform in ("win32", "cygwin"):
         logger.debug("Detected Windows OS")
 
         os_lib_name = JEP_OS_LIB_NAME_WINDOWS


### PR DESCRIPTION
This adds support for macOS (#34) on x86_64. ARM Macs may or may not work - unfortunately I don't have an Apple Silicon machine to test on.

Tested with Ghidra 10.2.3 and Python 3.9~3.11, where ghidrathon_example.py seems to run fine.