### PR TITLE
Use python3 specifically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ if (project.hasProperty("PYTHON_BIN")) {
 	pythonBin = project.getProperty("PYTHON_BIN")
 }
 else {
-	pythonBin = "python"
+	pythonBin = "python3"
 }
 
 // we need to install Jep; this requires C++ build tools on Windows (see README); we need to define


### PR DESCRIPTION
`python` is no longer included on macOS. Explicitly setting `python3` seems more inline with project goals.