### PR TITLE
use installed JEP DLL rather than packaged DLL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,37 +22,6 @@
 // application.gradle.version property in <GHIDRA_INSTALL_DIR>/Ghidra/application.properties
 // for the correction version of Gradle to use for the Ghidra installation you specify.
 
-def javaHome
-def pythonBin
-
-if (project.hasProperty("PYTHON_BIN")) {
-	pythonBin = project.getProperty("PYTHON_BIN")
-}
-else {
-	pythonBin = "python"
-}
-
-// we need to install Jep; this requires C++ build tools on Windows (see README); we need to define
-// the env variable "JAVA_HOME" containing absolute path to Java JDK configured for Ghidra
-task installJep(type: Exec) {
-    environment "JAVA_HOME", System.getProperty("java.home")
-    commandLine pythonBin, '-m', 'pip', 'install', 'jep'
-}
-
-// we need to copy the Jep native binaries built in installJep to our extension directory; we use a small
-// utility script written in Python
-task copyJepNativeBinaries(type: Exec) {
-    dependsOn installJep
-    workingDir "${projectDir}"
-    commandLine pythonBin, "util${File.separator}configure_jep_native_binaries.py"
-}
-
-// make all tasks not matching copyJepNativeBinaries or installJep depend on copyJepNativeBinaries; mostly
-// used to ensure our tasks run before Ghidra buildExtension task
-tasks.matching { it.name != 'copyJepNativeBinaries' && it.name != 'installJep' }.all { Task task ->
-    task.dependsOn copyJepNativeBinaries
-}
-
 // from here we use the standard Gradle build provided by Ghidra framework
 
 //----------------------START "DO NOT MODIFY" SECTION------------------------------

--- a/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
+++ b/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
@@ -10,19 +10,6 @@
 
 package ghidrathon.interpreter;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-
 import generic.jar.ResourceFile;
 import ghidra.app.script.GhidraScript;
 import ghidra.app.script.GhidraScriptUtil;
@@ -31,17 +18,27 @@ import ghidrathon.GhidrathonClassEnquirer;
 import ghidrathon.GhidrathonConfig;
 import ghidrathon.GhidrathonScript;
 import ghidrathon.GhidrathonUtils;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.IOException;
 import java.lang.reflect.*;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import jep.Jep;
 import jep.JepConfig;
 import jep.JepException;
 import jep.MainInterpreter;
 import jep.PyConfig;
 import org.apache.commons.io.output.WriterOutputStream;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 

--- a/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
+++ b/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
@@ -67,102 +67,86 @@ public class GhidrathonInterpreter {
   private GhidrathonInterpreter(GhidrathonConfig config) throws JepException, IOException {
     log.info("GhidrathonInterpreter constructor 1");
 
-    try {
-      ghidrathonConfig = config;
+    ghidrathonConfig = config;
 
-      // configure the Python includes path with the user's Ghdira script directory
-      String paths = "";
-      for (ResourceFile resourceFile : GhidraScriptUtil.getScriptSourceDirectories()) {
+    // configure the Python includes path with the user's Ghdira script directory
+    String paths = "";
+    for (ResourceFile resourceFile : GhidraScriptUtil.getScriptSourceDirectories()) {
 
-        paths += resourceFile.getFile(false).getAbsolutePath() + File.pathSeparator;
-      }
-
-      // add data/python/ to Python includes directory
-      paths +=
-          Application.getModuleDataSubDirectory(GhidrathonUtils.THIS_EXTENSION_NAME, "python")
-              + File.pathSeparator;
-
-      // add paths specified in Ghidrathon config
-      for (String path : ghidrathonConfig.getPythonIncludePaths()) {
-
-        paths += path + File.pathSeparator;
-      }
-
-      // configure Java names that will be ignored when importing from Python
-      for (String name : ghidrathonConfig.getJavaExcludeLibs()) {
-
-        ghidrathonClassEnquirer.addJavaExcludeLib(name);
-      }
-
-      // set the class loader with access to Ghidra scripting API
-      jepConfig.setClassLoader(ClassLoader.getSystemClassLoader());
-
-      // set class enquirer used to handle Java imports from Python
-      jepConfig.setClassEnquirer(ghidrathonClassEnquirer);
-
-      // configure Python includes Path
-      jepConfig.addIncludePaths(paths);
-
-      // add Python shared modules - these should be CPython modules for Jep to handle specially
-      for (String name : ghidrathonConfig.getPythonSharedModules()) {
-
-        jepConfig.addSharedModules(name);
-      }
-
-      // configure Jep stdout
-      if (ghidrathonConfig.getStdOut() != null) {
-
-        jepConfig.redirectStdout(
-            new WriterOutputStream(
-                ghidrathonConfig.getStdOut(), System.getProperty("file.encoding")) {
-
-              @Override
-              public void write(byte[] b, int off, int len) throws IOException {
-                super.write(b, off, len);
-                flush(); // flush the output to ensure it is displayed in real-time
-              }
-            });
-      }
-
-      // configure Jep stderr
-      if (ghidrathonConfig.getStdErr() != null) {
-        jepConfig.redirectStdErr(
-            new WriterOutputStream(
-                ghidrathonConfig.getStdErr(), System.getProperty("file.encoding")) {
-
-              @Override
-              public void write(byte[] b, int off, int len) throws IOException {
-                super.write(b, off, len);
-                flush(); // flush the error to ensure it is displayed in real-time
-              }
-            });
-      }
-
-      // we must set the native Jep library before creating a Jep instance
-      try {
-        setJepPaths();
-      } catch (Exception e) {
-        log.info("error setting JEP paths: " + e.toString());
-        return;
-      }
-
-      try {
-        // create a new Jep interpreter instance
-        jep = new jep.SubInterpreter(jepConfig);
-
-        // now that everything is configured, we should be able to run some utility scripts
-        // to help us further configure the Python environment
-        setJepEval();
-        setJepRunScript();
-        
-      } catch (Exception e) {
-        log.info("error creating JEP interpreter: " + e.toString());
-        return;
-      }
-    } catch (Exception e) {
-      log.info("error: " + e.toString());
-      return;
+      paths += resourceFile.getFile(false).getAbsolutePath() + File.pathSeparator;
     }
+
+    // add data/python/ to Python includes directory
+    paths +=
+        Application.getModuleDataSubDirectory(GhidrathonUtils.THIS_EXTENSION_NAME, "python")
+            + File.pathSeparator;
+
+    // add paths specified in Ghidrathon config
+    for (String path : ghidrathonConfig.getPythonIncludePaths()) {
+
+      paths += path + File.pathSeparator;
+    }
+
+    // configure Java names that will be ignored when importing from Python
+    for (String name : ghidrathonConfig.getJavaExcludeLibs()) {
+
+      ghidrathonClassEnquirer.addJavaExcludeLib(name);
+    }
+
+    // set the class loader with access to Ghidra scripting API
+    jepConfig.setClassLoader(ClassLoader.getSystemClassLoader());
+
+    // set class enquirer used to handle Java imports from Python
+    jepConfig.setClassEnquirer(ghidrathonClassEnquirer);
+
+    // configure Python includes Path
+    jepConfig.addIncludePaths(paths);
+
+    // add Python shared modules - these should be CPython modules for Jep to handle specially
+    for (String name : ghidrathonConfig.getPythonSharedModules()) {
+
+      jepConfig.addSharedModules(name);
+    }
+
+    // configure Jep stdout
+    if (ghidrathonConfig.getStdOut() != null) {
+
+      jepConfig.redirectStdout(
+          new WriterOutputStream(
+              ghidrathonConfig.getStdOut(), System.getProperty("file.encoding")) {
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+              super.write(b, off, len);
+              flush(); // flush the output to ensure it is displayed in real-time
+            }
+          });
+    }
+
+    // configure Jep stderr
+    if (ghidrathonConfig.getStdErr() != null) {
+      jepConfig.redirectStdErr(
+          new WriterOutputStream(
+              ghidrathonConfig.getStdErr(), System.getProperty("file.encoding")) {
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+              super.write(b, off, len);
+              flush(); // flush the error to ensure it is displayed in real-time
+            }
+          });
+    }
+
+    // we must set the native Jep library before creating a Jep instance
+    setJepPaths();
+
+    // create a new Jep interpreter instance
+    jep = new jep.SubInterpreter(jepConfig);
+
+    // now that everything is configured, we should be able to run some utility scripts
+    // to help us further configure the Python environment
+    setJepEval();
+    setJepRunScript();
   }
 
   private PathMatcher getJepDllPathMatcher() throws Exception {


### PR DESCRIPTION
This PR addresses #49 and makes Ghidrathon substantially easier to install: it relies on the jep.dll built during `pip install jep` and therefore doesn't require a Gradle build step by the user. Instead, everyone can use the same pre-built Ghidrathon.zip. An example is attached. In theory it should be a drop-in replacement for whatever Ghidrathon.zip you have already.

The PR updates the interpreter configuration to search for the jep.dll in three places:
  - when PYTHONPATH is set, which a user may do to specify a specific virtualenv,
  - when VIRTUAL_ENV is set, such as when a virtualenv is "activated",
  - all the entries from sys.path used by whatever python3 uses

This works on my Windows system, Ghidra 10.3. I need to test this further, especially on my m1 Mac Mini. We should also setup testing in CI/CD to demonstrate this works on those platforms. Finally, documentation updates are needed if this PR is approved.

TODO:
- [ ] manual testing on linux
- [ ] manual testing on macOS (x86)
- [ ] manual testing on macOS (arm64)
- [ ] CI/CD testing
- [ ] docstrings on all functions
- [ ] handle VIRTUAL_ENV only scenario

If merged, this supercedes #4 #46 and #48 and closes #1 #3 #10 #27 #34 and #49

[ghidra_10.3_PUBLIC_20230613_Ghidrathon-50.zip](https://github.com/mandiant/Ghidrathon/files/11736396/ghidra_10.3_PUBLIC_20230613_Ghidrathon-50.zip)

