### PR TITLE
fix python executable on mac

### DIFF
--- a/data/GhidrathonConfig.xml
+++ b/data/GhidrathonConfig.xml
@@ -3,9 +3,7 @@
     <ARRAY NAME="JAVA_EXCLUDE_LIBS" TYPE="string">
         <A VALUE="pdb" />
     </ARRAY>
-    <ARRAY NAME="PYTHON_SHARED_MODULES" TYPE="string">
-        <A VALUE="numpy" />
-    </ARRAY>
+    <STATE NAME="PYTHON_EXECUTABLE" TYPE="string" VALUE="/usr/local/bin/python" />
     <ARRAY NAME="PYTHON_INCLUDE_PATHS" TYPE="string">
     </ARRAY>
 </GHIDRATHON_CONFIG>

--- a/src/main/java/ghidrathon/GhidrathonConfig.java
+++ b/src/main/java/ghidrathon/GhidrathonConfig.java
@@ -26,7 +26,7 @@ public class GhidrathonConfig {
 
   private final List<String> javaExcludeLibs = new ArrayList<String>();
   private final List<String> pyIncludePaths = new ArrayList<String>();
-  private final List<String> pySharedModules = new ArrayList<String>();
+  private String pyExecutable = new String();
 
   private PrintWriter out = null;
   private PrintWriter err = null;
@@ -47,16 +47,12 @@ public class GhidrathonConfig {
     return err;
   }
 
-  public void addPythonSharedModule(String name) {
-    pySharedModules.add(name);
+  public void addPyExecutable(String path) {
+    pyExecutable = path;
   }
 
-  public void addPythonSharedModules(List<String> names) {
-    pySharedModules.addAll(names);
-  }
-
-  public Iterable<String> getPythonSharedModules() {
-    return Collections.unmodifiableList(pySharedModules);
+  public String getPyExecutable() {
+    return pyExecutable;
   }
 
   public void addJavaExcludeLib(String name) {

--- a/src/main/java/ghidrathon/GhidrathonUtils.java
+++ b/src/main/java/ghidrathon/GhidrathonUtils.java
@@ -26,7 +26,7 @@ public class GhidrathonUtils {
 
   private static final String DEFAULT_CONFIG_FILENAME = "GhidrathonConfig.xml";
   private static final String JAVA_EXCLUDE_LIBS_KEY = "JAVA_EXCLUDE_LIBS";
-  private static final String PY_SHARED_MODULES_KEY = "PYTHON_SHARED_MODULES";
+  private static final String PY_EXECUTABLE_KEY = "PYTHON_EXECUTABLE";
   private static final String PY_INCLUDE_PATHS_KEY = "PYTHON_INCLUDE_PATHS";
 
   /**
@@ -86,12 +86,12 @@ public class GhidrathonUtils {
       config.addPythonIncludePath(name);
     }
 
-    // add Python shared modules - these modules are handled specially by Jep to avoid crashes
-    // caused
-    // by CPython extensions, e.g. numpy
-    for (String name : state.getStrings(PY_SHARED_MODULES_KEY, new String[0])) {
+    // add Python executable if user configures it
+    String name = state.getString(PY_EXECUTABLE_KEY, "");
 
-      config.addPythonSharedModule(name);
+    if (!name.isEmpty()) {
+
+      config.addPyExecutable(name);
     }
 
     return config;

--- a/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
+++ b/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
@@ -119,7 +119,7 @@ public class GhidrathonInterpreter {
   }
 
   /** Extends Python sys.path to include Ghidra script source directories */
-  private void setSysPath() {
+  private void setPySys() {
     String paths = "";
 
     for (ResourceFile resourceFile : GhidraScriptUtil.getScriptSourceDirectories()) {
@@ -133,6 +133,11 @@ public class GhidrathonInterpreter {
             + "'.split('"
             + File.pathSeparator
             + "') if path not in sys.path])");
+
+    String executable = config.getPyExecutable();
+    if (!executable.isEmpty()) {
+      jep_.eval("sys.executable='" + executable + "'");
+    }
   }
 
   /**
@@ -330,7 +335,7 @@ public class GhidrathonInterpreter {
 
     try {
 
-      setSysPath();
+      setPySys();
       setStreams();
 
       return (boolean) jep_.invoke("jepeval", line);
@@ -368,7 +373,7 @@ public class GhidrathonInterpreter {
 
     try {
 
-      setSysPath();
+      setPySys();
       setStreams();
 
       return (boolean) jep_.invoke("jepeval", line);
@@ -392,7 +397,7 @@ public class GhidrathonInterpreter {
 
     try {
 
-      setSysPath();
+      setPySys();
       setStreams();
 
       jep_.invoke("jep_runscript", file.getAbsolutePath());
@@ -420,7 +425,7 @@ public class GhidrathonInterpreter {
 
       injectScriptHierarchy(script);
 
-      setSysPath();
+      setPySys();
       setStreams();
 
       jep_.invoke("jep_runscript", file.getAbsolutePath());


### PR DESCRIPTION
Provide a new configuration item in the `Ghidrathon.xml`, so that the user can define their python executable on specific platform, this may also be useful when venv-like environment is used, close #62

It seems `PYTHON_SHARED_MODULES` is no longer needed, so I remove it. 

BTW, it takes me a lot of time to find the valid XML element name `STATE` for `PYTHON_EXECUTABLE`. Is there any related doc? 