### PR TITLE
expose GhidraState object using state function added to Python builtins

### DIFF
--- a/data/python/jepwrappers.py
+++ b/data/python/jepwrappers.py
@@ -307,6 +307,10 @@ def wrapped_monitor():
     return get_script().getMonitor()
 
 
+def wrapped_state():
+    return get_script_state()
+
+
 def wrapped_currentProgram():
     return get_script_state().getCurrentProgram()
 
@@ -328,6 +332,7 @@ def wrapped_currentHighlight():
 
 
 __builtins__["monitor"] = wrapped_monitor
+__builtins__["state"] = wrapped_state
 __builtins__["currentProgram"] = wrapped_currentProgram
 __builtins__["currentAddress"] = wrapped_currentAddress
 __builtins__["currentLocation"] = wrapped_currentLocation

--- a/data/python/tests/test_jepbridge.py
+++ b/data/python/tests/test_jepbridge.py
@@ -46,6 +46,7 @@ class TestJepBridge(unittest.TestCase):
 
     def test_ghidra_script_variables(self):
         self.assertIsJavaObject(monitor())
+        self.assertIsJavaObject(state())
         self.assertIsJavaObject(currentAddress())
         self.assertIsJavaObject(currentProgram())
         self.assertIsJavaObject(currentLocation())
@@ -53,6 +54,7 @@ class TestJepBridge(unittest.TestCase):
         self.assertIsJavaObject(currentSelection())
 
         self.assertIsNotJavaObject(monitor)
+        self.assertIsNotJavaObject(state)
         self.assertIsNotJavaObject(currentAddress)
         self.assertIsNotJavaObject(currentProgram)
         self.assertIsNotJavaObject(currentLocation)
@@ -61,8 +63,12 @@ class TestJepBridge(unittest.TestCase):
 
     def test_ghidra_script_methods(self):
         self.assertIsInstance(getGhidraVersion(), str)
+        self.assertIsJavaObject(getState())
 
     def test_java_excluded_packages(self):
         import pdb
 
         self.assertIsNotJavaObject(pdb)
+
+    def test_ghidra_script_state(self):
+        self.assertTrue(state() == getState())


### PR DESCRIPTION
Jython exposes the `GhidraState` object through a variable named `state` that is available to the scripting environment, similar to `currentProgram` and friends. This PR adds similar support in Ghidrathon where the `GhidraState` object is exposed through a function named `state` that is added to the Python `builtins` scope.

The following is an example of accessing the new `state` function:

```python
> state()  == getState()
True
```

Fixes #74 