### PR TITLE
Add basic autocompletion

### DIFF
--- a/data/python/complete.py
+++ b/data/python/complete.py
@@ -1,0 +1,268 @@
+import ast
+import inspect
+import types
+
+import java
+
+from ghidrathon import PythonCodeCompletionFactory
+
+
+def isJavaModule(module):
+    modules = ['ghidra.', 'java.']
+    return any(module.startswith(name) for name in modules)
+
+
+def isJavaMethod(obj):
+    "Returns whether the given object is a bound method implemented in Java"
+    return (isinstance(obj, types.MethodType) and hasattr(obj, '__self__') and hasattr(obj.__self__, '__module__') and isJavaModule(obj.__self__.__module__)) or obj.__class__.__name__ == "PythonCodeCompletionFactory$InspectableJavaMethod"
+
+
+class CompletionObject:
+    "Object returned by getObject. See the documentation of getObject"
+    def __init__(self, o):
+        self.obj = o
+
+    def getmembers(self):
+        "Returns the properties of the encapsulated object as a (name, value) tuple"
+        if self.obj.__class__.__name__ == "PythonCodeCompletionFactory$InspectableJavaObject":
+            return self.obj.getProperties()
+        return inspect.getmembers(self.obj)
+
+
+def getObject(value, locals):
+    """
+    Attempts to resolve the object that would be generated when evaluating
+    the AST `value` within the local variables `locals`.
+    This method does not run any python code and thus does not produce
+    side effects.
+    This also means we may not have enough information to determine which
+    object would be produced by this expression.
+
+    This function returns a CompletionObject if the object produced by this
+    expression could be found. If not, this function returns None.
+
+    Note: In case a method call on a Java object is processed, we return
+    a `PythonCodeCompletionFactory$InspectableJavaObject` that fakes the
+    properties and methods of the Java Object that would be returned if
+    called. This is necessary, as calling the function could produce side
+    effects.
+
+    On a similar note, for python functions we also cannot return the actual
+    object that would be returned. In this case we return the returntype of
+    the function signature (if available). This should mostly work but may
+    be missing properties that are dynamically assigned on such an object
+    during creation. But this is currently the best we can do for python.
+    """
+    match value:
+        case ast.Constant(literal):
+            return CompletionObject(literal)
+        case ast.Name(id, ctx):
+            try:
+                # Get object
+                obj = eval(id, locals)
+                return CompletionObject(obj)
+            except NameError:
+                return None
+        case ast.Call(func, _, _):
+            prop = getObject(func, locals)
+            retval = None
+
+            # Hack to introspect java methods
+            if prop and isJavaMethod(prop.obj):
+                retval = PythonCodeCompletionFactory.getReturnType(prop.obj.__self__, prop.obj.__name__)
+                if retval and retval.getSrcClass() == java.lang.String:
+                    # jep autoconverts between basic types
+                    # There are more of these edge cases but this one happens the most
+                    retval = ''
+            # If it ain't java, we may have a python signature
+            # if not, then we are lost
+            elif prop and inspect.signature(prop.obj).return_annotation:
+                retval = inspect.signature(prop.obj).return_annotation
+            if retval:
+                return CompletionObject(retval)
+            return None
+        case ast.Attribute(value, attr, _):
+            prop = getObject(value, locals)
+            props = [y for (x, y) in prop.getmembers() if x == attr]
+            if props:
+                # There may be multiple functions with different signatures
+                # This only happens when those members are reported through
+                # PythonCodeCompletionFactory$InspectableJavaObject.getProperties()
+                # and not when inspected via python
+                # This is bad for our cause, but we just have to live with that
+                # Just pick one, we don't check the signature anyways
+                # And luckily they all have the same return type
+                return CompletionObject(props[0])
+            return None
+        case ast.Subscript | ast.ListComp | ast.SetComp | ast.GeneratorExp | ast.DictComp:
+            # TODO, can we handle this?
+            return None
+        case default:
+            raise ValueError(f"I don't know how to handle '{ast.dump(default)}' (getObject)")
+
+
+def getProperties(value, locals):
+    """
+    Returns a list of properties of the AST given by `value` when evaluated
+    within the local variables `locals`
+    Each entry of the returned list is of the form (name, prop).
+    `name` is a string and `prop` is the value of that property.
+    Because we do not actually run this code, we may not have enough
+    information to offer introspection for this value. In this case
+    the resulting list is empty
+    """
+    prop = getObject(value, locals)
+    if prop:
+        return prop.getmembers()
+    return []
+
+
+def getVariables(locals):
+    """
+    Returns all variables in the local scope and the builtins.
+    That is because most of the jepwrappers are bound to the builtins...
+    And thus don't show up in the local scope
+    """
+    return [(x, locals[x]) for x in locals if locals[x] != locals] + \
+        [(x, __builtins__[x]) for x in __builtins__]
+
+
+def makeCompletions(values, prefix=''):
+    """
+    Returns a list of CodeCompletion objects for all properties in the list
+    that start with the given prefix.
+    """
+    return [PythonCodeCompletionFactory.newCodeCompletion(name, name[len(prefix):], value)
+            for name, value in values if name.startswith(prefix)]
+
+
+def completeAST(parsed, locals, needs_property):
+    """
+    Tries to provide autocompletion suggestions for the AST given by `parsed`
+    with the variables in scope given by locals.
+    Due to the way we have to handle property access, we need
+    a special case when the original input ended with a trailing point.
+    Therefore if `needs_property` is True, we return the properties of
+    the object returned if the given AST were to be evaluated.
+    If `needs_property` is False instead, we treat the last property access
+    in the AST as unfinished and report all properties that start with the last
+    property name as a prefix.
+    See the complete function for more information
+    """
+    match parsed:
+        case ast.Constant(literal):
+            if needs_property:
+                return makeCompletions(getProperties(parsed, locals))
+            return []
+        case ast.Expr(value):
+            return completeAST(value, locals, needs_property)
+        case ast.UnaryOp(_, operand):
+            return completeAST(operand, locals, needs_property)
+        case ast.BinOp(_, _, right):
+            return completeAST(right, locals, needs_property)
+        case ast.BoolOp(_, values):
+            return completeAST(values[-1], locals, needs_property)
+        case ast.Compare(_, _, comparators):
+            return completeAST(comparators, locals, needs_property)
+        case ast.Name(id, _):
+            if needs_property:
+                return makeCompletions(getProperties(parsed, locals))
+            return makeCompletions(getVariables(locals), id)
+        case ast.Call(func, _, _):
+            if needs_property:
+                return makeCompletions(getProperties(parsed, locals))
+            # This is a valid function call and not an unfinished fragment
+            # There is nothing to complete
+            return []
+        case ast.IfExp(_, _, orelse):
+            return completeAST(orelse, locals, needs_property)
+        case ast.Attribute(value, attr, _):
+            if needs_property:
+                # We need to complete a full property at the end
+                return makeCompletions(getProperties(parsed, locals), '')
+            # We already typed part of the property, let's see what we could complete
+            return makeCompletions(getProperties(value, locals), attr)
+        case ast.NamedExpr():
+            # Of the form (x := 4). If this is parsed, then it is already complete
+            # Therefore there's nothing to complete here
+            return []
+        case ast.Subscript() | ast.ListComp() | ast.SetComp() | ast.GeneratorExp() | ast.DictComp():
+            if needs_property:
+                # Just pass introspection to getProperties
+                return makeCompletions(getProperties(parsed, locals), '')
+            # This is a valid expression and not an unfinished fragment
+            # There is nothing to complete
+            return []
+        case ast.Starred(value, _):
+            return completeAST(value, locals, needs_property)
+        case ast.Assign(_, value, _):
+            return completeAST(value, locals, needs_property)
+        case ast.AnnAssign(_, _, value, _):
+            return completeAST(value, locals, needs_property)
+        case ast.AugAssign(_, _, value):
+            return completeAST(value, locals, needs_property)
+        case ast.Raise(exc, cause):
+            if cause:
+                return completeAST(cause, locals, needs_property)
+            return completeAST(exc, locals, needs_property)
+        case ast.Assert(test, msg):
+            if msg:
+                return completeAST(msg, locals, needs_property)
+            return completeAST(test, locals, needs_property)
+        case ast.Delete(targets):
+            return completeAST(targets[-1], locals, needs_property)
+        case ast.Pass | ast.Break | ast.Continue:
+            return []
+        case ast.Return(value):
+            if value:
+                return completeAST(value, locals, needs_property)
+            return []
+        case ast.Lambda(_, body):
+            return completeAST(body, locals, needs_property)
+        case ast.Yield(value) | ast.YieldFrom(value):
+            return completeAST(body, locals, needs_property)
+        case ast.Import() | ast.ImportFrom():
+            # TODO, import autocompletion?
+            return []
+        case ast.Global() | ast.Nonlocal():
+            # TODO, autocomplete variable names?
+            return []
+        # All other cases should be multi-line expressions, which our
+        # interpreter console does not support
+        case default:
+            raise ValueError(f"I don't know how to handle '{ast.dump(default)}' (completeAST)")
+
+
+def complete(cmd, locals):
+    """
+    Tries to provide autocompletion suggestions for the input string `cmd`
+    with the variables in scope given by locals.
+    """
+    # Python with a trailing point will never compile
+    # We have to handle this special case seperately
+    needs_property = cmd.endswith('.')
+    # Special case: floating point literals, e.g.
+    # 0. is parsed as a float in python ;)
+    if len(cmd) > 2 and cmd[-2] in '0123456789':
+        needs_property = False
+    if needs_property:
+        cmd = cmd[:-1]
+
+    # CMD may not be valid python, therefore we
+    # get the longest suffix that is syntactically correct
+    # This should work most of the time
+    parsed = None
+    while True:
+        # Uh oh, there is no valid expression
+        if not cmd:
+            # Just return a list of the locals
+            return makeCompletions(getVariables(locals))
+
+        try:
+            parsed = ast.parse(cmd, mode='single')
+            break
+        except SyntaxError:
+            cmd = cmd[1:].lstrip()
+    # Parsed will always be of type ast.Interactive
+    # We only have to complete the last expression
+    return completeAST(parsed.body[-1], locals, needs_property)

--- a/src/main/java/ghidrathon/PythonCodeCompletionFactory.java
+++ b/src/main/java/ghidrathon/PythonCodeCompletionFactory.java
@@ -1,0 +1,281 @@
+/* ###
+ * IP: GHIDRATHON
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Taken from https://github.com/NationalSecurityAgency/ghidra/blob/d7d6b44e296ac4a215766916d5c24e8b53b2909a/Ghidra/Features/Python/src/main/java/ghidra/python/PythonCodeCompletionFactory.java
+package ghidrathon;
+
+import java.awt.Color;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.*;
+
+import javax.swing.JComponent;
+
+import jep.python.PyObject;
+import jep.JepException;
+
+import docking.widgets.label.GDLabel;
+import ghidra.app.plugin.core.console.CodeCompletion;
+import ghidra.framework.options.Options;
+import ghidra.util.Msg;
+
+/**
+ * Generates CodeCompletions from Python objects.
+ * 
+ * 
+ *
+ */
+public class PythonCodeCompletionFactory {
+  private static class InspectableJavaObject<T> {
+    private Class<T> srcClass;
+
+    public InspectableJavaObject(Class<T> c) {
+      srcClass = c;
+    }
+
+    public Class<T> getSrcClass() {
+      return srcClass;
+    }
+
+    /**
+     * Returns the Java methods declared for a given object
+     * @param obj a Java Object
+     * @return the Java method names and a proxy that can be inspected as well
+     */
+    public List<Object[]> getProperties() {
+      List<Object[]> properties = new ArrayList<>();
+      Method[] declaredMethods = srcClass.getMethods();
+      Field[] declaredFields = srcClass.getFields();
+      
+      for (Method declaredMethod : declaredMethods) {
+        properties.add(new Object [] {
+          declaredMethod.getName(),
+          new InspectableJavaMethod(this, declaredMethod)
+        });
+      }
+
+      for (Field declaredField : declaredFields) {
+        properties.add(new Object [] {
+          declaredField.getName(),
+          new InspectableJavaObject(declaredField.getType())
+        });
+      }
+
+      return properties;
+    }
+  }
+
+  private static class InspectableJavaMethod {
+    private Method method;
+    public String __name__;
+    public Object __self__;
+
+    public InspectableJavaMethod(Object o, Method m) {
+      method = m;
+      __name__ = m.getName();
+      __self__ = o;
+    }
+
+    public Method getMethod() {
+      return method;
+    }
+  }
+
+  
+  private static Map<String, Color> typeToColorMap = new HashMap<>();
+  public static final String COMPLETION_LABEL = "Code Completion Colors";
+
+  /* package-level accessibility so that PythonPlugin can tell this is
+   * our option
+   */
+  final static String INCLUDE_TYPES_LABEL = "Include type names in code completion popup?";
+  private final static String INCLUDE_TYPES_DESCRIPTION =
+    "Whether or not to include the type names (classes) of the possible " +
+    "completions in the code completion window.  The class name will be " +
+    "parenthesized after the completion.";
+  private final static boolean INCLUDE_TYPES_DEFAULT = true;
+  private static boolean includeTypes = INCLUDE_TYPES_DEFAULT;
+
+  public static final Color NULL_COLOR = new Color(255, 0, 0);
+  public static final Color FUNCTION_COLOR = new Color(0, 128, 0);
+  public static final Color PACKAGE_COLOR = new Color(128, 0, 0);
+  public static final Color CLASS_COLOR = new Color(0, 0, 255);
+  public static final Color METHOD_COLOR = new Color(0, 128, 128);
+  /* anonymous code chunks */
+  public static final Color CODE_COLOR = new Color(0, 64, 0);
+  public static final Color INSTANCE_COLOR = new Color(128, 0, 128);
+  public static final Color SEQUENCE_COLOR = new Color(128, 96, 64);
+  public static final Color MAP_COLOR = new Color(64, 96, 128);
+  public static final Color NUMBER_COLOR = new Color(64, 64, 64);
+
+  static {
+    setupClass("NoneType", NULL_COLOR);
+
+    setupClass("builtin_function_or_method", FUNCTION_COLOR);
+    setupClass("function", FUNCTION_COLOR);
+
+    setupClass("module", PACKAGE_COLOR);
+
+    setupClass("str", SEQUENCE_COLOR);
+    setupClass("bytes", SEQUENCE_COLOR);
+    setupClass("list", SEQUENCE_COLOR);
+    setupClass("tuple", SEQUENCE_COLOR);
+    setupClass("dict", MAP_COLOR);
+
+    setupClass("int", NUMBER_COLOR);
+    setupClass("float", NUMBER_COLOR);
+    setupClass("complex", NUMBER_COLOR);
+  }
+
+  /**
+   * Returns the type name for a Python Object.
+   * 
+   * @param pyObj Object to determine to type name
+   * @return The type name.
+   */
+  private static String getTypeName(PyObject pyObj) {
+    return pyObj.getAttr("__class__", PyObject.class).getAttr("__name__", String.class);
+  }
+
+  /**
+   * Sets up a Type mapping.
+   * 
+   * @param typeName Type name
+   * @param defaultColor default Color for this type
+   * @param description description of the type
+   */
+  private static void setupClass(String typeName, Color defaultColor) {
+    typeToColorMap.put(typeName, defaultColor);
+  }
+
+  /**
+   * Creates a new CodeCompletion from the given Python objects.
+   * 
+   * @param description description of the new CodeCompletion
+   * @param insertion what will be inserted to make the code complete
+   * @param pyObj a Python Object
+   * @return A new CodeCompletion from the given Python objects.
+   */
+  public static CodeCompletion newCodeCompletion(String description, String insertion,
+                                                 Object obj) {
+    JComponent comp = null;
+
+    if (obj != null) {
+      String type;
+      Color color;
+      if ((obj instanceof PyObject)) {
+        type = getTypeName((PyObject) obj);
+        color = typeToColorMap.get(type);
+      } else {
+        type = obj.getClass().getSimpleName();
+        color = CLASS_COLOR;
+      }
+      if (includeTypes) {
+        description = description + " (" + type + ")";
+      }
+
+      comp = new GDLabel(description);
+      if (color != null) {
+        comp.setForeground(color);
+      }
+    }
+    return new CodeCompletion(description, insertion, comp);
+  }
+
+  /**
+   * Returns the Java methods declared for a given object
+   * @param obj a Java Object
+   * @return the Java method names and a proxy that can be inspected as well
+   */
+  public static Object getReturnType(Object obj, String name) {
+    Class<?> c;
+    if (obj instanceof InspectableJavaObject) {
+      c = ((InspectableJavaObject) obj).getSrcClass();
+    } else {
+      c = obj.getClass();
+    }
+
+    return new InspectableJavaObject(getReturnTypeForClass(c, name));
+  }
+
+  /**
+   * Returns the Java methods declared for a given java class
+   * @param obj a Java Object
+   * @return the Java method names and a proxy that can be inspected as well
+   */
+  public static Class getReturnTypeForClass(Class c, String name) {
+    Method[] declaredMethods = c.getMethods();
+
+    for (Method declaredMethod : declaredMethods) {
+      if (declaredMethod.getName().equals(name)) {
+        return declaredMethod.getReturnType();
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Sets up Python code completion Options.
+   * @param plugin python plugin as options owner
+   * @param options an Options handle
+   */
+  public static void setupOptions(GhidrathonPlugin plugin, Options options) {
+    includeTypes = options.getBoolean(INCLUDE_TYPES_LABEL, INCLUDE_TYPES_DEFAULT);
+    options.registerOption(INCLUDE_TYPES_LABEL, INCLUDE_TYPES_DEFAULT, null,
+                           INCLUDE_TYPES_DESCRIPTION);
+
+    Iterator<?> iter = typeToColorMap.keySet().iterator();
+    while (iter.hasNext()) {
+      String currentType = (String) iter.next();
+      options.registerOption(
+        COMPLETION_LABEL + Options.DELIMITER + currentType,
+        typeToColorMap.get(currentType), null,
+        "Color to use for '" + currentType + "'.");
+      typeToColorMap.put(currentType,
+                         options.getColor(COMPLETION_LABEL + Options.DELIMITER + currentType,
+                                          typeToColorMap.get(currentType)));
+    }
+  }
+
+  /**
+   * Handle an Option change.
+   * 
+   * This is named slightly differently because it is a static method, not
+   * an instance method.
+   * 
+   * By the time we get here, we assume that the Option changed is indeed
+   * ours. 
+   * 
+   * @param options the Options handle
+   * @param name name of the Option changed
+   * @param oldValue the old value
+   * @param newValue the new value
+   */
+  public static void changeOptions(Options options, String name, Object oldValue,
+                                   Object newValue) {
+    String typeName = name.substring((COMPLETION_LABEL + Options.DELIMITER).length());
+
+    if (typeToColorMap.containsKey(typeName)) {
+      typeToColorMap.put(typeName, (Color) newValue);
+    }
+    else if (name.equals(INCLUDE_TYPES_LABEL)) {
+      includeTypes = ((Boolean) newValue).booleanValue();
+    }
+    else {
+      Msg.error(PythonCodeCompletionFactory.class, "unknown option '" + name + "'");
+    }
+  }
+}


### PR DESCRIPTION
Resolves #5 

This should work for most exposed java functionality. Getting code completion for python is more complicated due to dynamic typing.

I first tried to port the existing Jython code  from the ghidra repository. But this ultimately failed because the ghidra python2 code just didn't work even after porting it to valid python3. Furthermore, the java introspection side relied on jython features, which were also hard to port over.

So I gave up and wrote a new implementation. IMHO this code is more readable and robust, because it uses the python standard library to achieve most of it and no python magic and doesn't use `eval()` everywhere. It mostly traverses the AST generated by python. The only case this code uses `eval` for is getting properties from local scope.

Still, a lot of the boilerplate on the Java side was copied over (and adapted) from the ghidra implementation, such as code completion colors.

How does this work? (Not a complete overview; only the important points)

The code is split in two parts. A Python side `complete.py`:
- finds the long suffix that parses as valid python via `ast.parse`
- then traverses the AST and tries to resolve the result of the expression. It uses these rules:
  - For variable names, we just resolve the object with `eval`
  - For property access, we use `inspect.getmembers` for a list of all members and find the one we want
  - For function calls this is more challenging. We first get the function object via the above rules and then handle two cases:
    1. If it's a Java function (determined by some heuristic), we invoke the Java `PythonCodeCompletionFactory.getReturnType`, which returns a faked java object of the return type. More on that later on
    2. If it's Python, the function may have a function signature with typed return value. In this case we return the type of that value. The class type shares all the functions in that object, which work well for code completion. However, this does not give us any hint about member variables that would be set on creation. If the function does not have a typed return value then we just give up.
- When an object could be determined, we get all members via `inspect.getmembers` and turn them into code completions. If we have a member typed out (e.g. `currentProgram().getM`), we filter this list by a prefix.

The Java side mostly resolves around implementing the "faked" objects returned by `PythonCodeCompletionFactory.getReturnType`.

We use a private inner class `InspectableJavaObject<T>`, which holds a reference to the `java.lang.Class` of the object we want to fake. We can then get a property list via `getProperties()`, these return either more `InspectableJavaObject`s for fields or another type `InspectableJavaMethod` for functions defined in that class. The `InspectableJavaMethod` needs a special case in the `getReturnType` implementation that resolves the Java Class of the object type we wanted to fake instead.

Additionally due to a jep limitation, an interpreter may only be used from the same thread it was created on. Therefore I had to move the interpreter to its own Java Thread. Any action to run on the interpreter can now be done by submitting Futures and waiting for their completion.

I also got rid of the `exec` call in `jepwrappers.py` as this made it hard to get the type information into the signature of the wrapper functions.

# Limitations
`complete.py` uses a lot of match statements for traversing the AST. Unfortunately match statements are a relatively new addition to python only being added in 3.10. However, typing this out with `if ... else` chains is a nightmare. If this is a problem, we could fall back to no autocompletion in case the module cannot be loaded.

Furthermore, there is a special case for the `str` type. Jep converts between some Java and Python types automatically. This is mostly observed on `java.lang.String` <-> `str`

So when the java side reports that a function returns `java.lang.String`, the python side has to fix the type to `str` or else the completions are wrong. While this isn't pretty I'm not sure if there is a better solution.

The same problem applies to other types as well. However I fear the other cases are not as straight forward as this one. Additionally the string problem is the most common one, so this should work fine for most cases.

The Python `locals()` function cannot be evaluated directly from the java side, as it must be run from inside python. Unfortunately this is needed to get the local variables. The workaround is currently to eval and assign it to a variable that can be retrieved later, which is ugly because it pollutes the script environment (and needs a special case not to break the autocompletion)

As we are trying to parse the command character by character the completion runs in `O(n^2)` time, which could be a problem for longer inputs. For testing I tested completion on the string `"foo("*500 + "currentProgram().getM"` and completion results still completed instantly so this hopefully shouldn't be a problem. This string is already too long for the interpreter console anyways.

Completion on the python side are limited mostly by signatures on python functions. Therefore it is quite important that the builtin wrapper function return values are correctly typed or else code completion will not work on them.

Additionally, this code does not give any hints on the argument types or the number of arguments. This may be nontrivial though, especially considering the wrapper functions have no sensible function signature arguments, but accept any args.

Furthermore, this only covers the basic completion cases. More challenging cases such as array subscripts and import autocompletions are not covered at all.