### PR TITLE
update Jep requirement to 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The following tools are needed to build, install, and run Ghidrathon:
 Tool | Version |Source |
 |---|---|---|
 | Ghidra | `>= 10.3` | https://ghidra-sre.org |
-| Jep | `>= 4.1.1` | https://github.com/ninia/jep |
+| Jep | `4.2.0` | https://github.com/ninia/jep |
 | Gradle | `>= 7.3` | https://gradle.org/releases |
 | Python | `>= 3.8` | https://www.python.org/downloads |
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ else {
 // the env variable "JAVA_HOME" containing absolute path to Java JDK configured for Ghidra
 task installJep(type: Exec) {
     environment "JAVA_HOME", System.getProperty("java.home")
-    commandLine pythonBin, '-m', 'pip', 'install', 'jep'
+    commandLine pythonBin, '-m', 'pip', 'install', 'jep==4.2'
 }
 
 // we need to copy the Jep native binaries built in installJep to our extension directory; we use a small

--- a/data/python/jepwelcome.py
+++ b/data/python/jepwelcome.py
@@ -15,7 +15,7 @@ should only be called after the Jep subinterpreter has been configured.
 import sys
 
 
-message = """
+message = r"""
    _____ _     _     _           _   _                 
   / ____| |   (_)   | |         | | | |                
  | |  __| |__  _  __| |_ __ __ _| |_| |__   ___  _ __  

--- a/data/python/jepwrappers.py
+++ b/data/python/jepwrappers.py
@@ -311,6 +311,10 @@ def wrapped_state():
     return get_script_state()
 
 
+def wrapped_script():
+    return get_script()
+
+
 def wrapped_currentProgram():
     return get_script_state().getCurrentProgram()
 
@@ -333,6 +337,7 @@ def wrapped_currentHighlight():
 
 __builtins__["monitor"] = wrapped_monitor
 __builtins__["state"] = wrapped_state
+__builtins__["script"] = wrapped_script
 __builtins__["currentProgram"] = wrapped_currentProgram
 __builtins__["currentAddress"] = wrapped_currentAddress
 __builtins__["currentLocation"] = wrapped_currentLocation


### PR DESCRIPTION
Jep recently [released 4.2](https://github.com/ninia/jep/releases/tag/v4.2.0) that includes many improvements and bug fixes. Also, this closes #79 and fixes a character escaping error seen when using Python 3.12