### PR TITLE
Enhance/33 close interpreter window when sys.exit called

### DIFF
--- a/data/python/jepeval.py
+++ b/data/python/jepeval.py
@@ -14,6 +14,10 @@ gives us better control over handling multi-line statements
 
 jepeval_lines = []
 
+class InterpreterExit(Exception):
+    """Signal to Java that the interpreter should exit"""
+    pass
+
 
 def jepeval(line):
     """attempt to compile and eval a given Python statement
@@ -73,7 +77,8 @@ def jepeval(line):
     try:
         more_input_needed = _jepeval(line)
     except SystemExit as err:
-        more_input_needed = False
+        raise InterpreterExit()
+        # more_input_needed = False
     except Exception as err:
         # Python exceptions are printed in Python instead of Java to improve error messaging
         # in the Ghidra console window

--- a/src/main/java/ghidrathon/GhidrathonConsoleInputThread.java
+++ b/src/main/java/ghidrathon/GhidrathonConsoleInputThread.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.SwingUtilities;
 
 public class GhidrathonConsoleInputThread extends Thread {
 
@@ -159,6 +160,13 @@ public class GhidrathonConsoleInputThread extends Thread {
           new PrintWriter(console.getStdOut()));
 
       status = python.eval(line, interactiveScript);
+    } catch (GhidrathonInterpreterExitException e) {
+      // Gracefully shut down only the interpreter
+      dispose();  // Stop the input thread
+      SwingUtilities.invokeLater(() -> {
+        plugin.shutdownInterpreter();
+      });
+      return false;
     } finally {
       interactiveScript.end(false);
     }

--- a/src/main/java/ghidrathon/GhidrathonInterpreterExitException.java
+++ b/src/main/java/ghidrathon/GhidrathonInterpreterExitException.java
@@ -1,0 +1,7 @@
+package ghidrathon;
+
+public class GhidrathonInterpreterExitException extends RuntimeException {
+  public GhidrathonInterpreterExitException() {
+    super("Ghidrathon interpreter requested exit");
+  }
+}

--- a/src/main/java/ghidrathon/GhidrathonPlugin.java
+++ b/src/main/java/ghidrathon/GhidrathonPlugin.java
@@ -159,6 +159,31 @@ public class GhidrathonPlugin extends ProgramPlugin
     inputThread.start();
   }
 
+  void shutdownInterpreter() {
+    if (inputThread != null) {
+        inputThread.dispose();
+        inputThread = null;
+    }
+
+    if (console != null) {
+        console.dispose();
+        console = null;
+    }
+
+    interactiveScript = null;
+    interactiveTaskMonitor = null;
+
+    // Recreate a new console instance, so Ghidra re-registers it
+    SwingUtilities.invokeLater(() -> {
+        console = getTool()
+            .getService(InterpreterPanelService.class)
+            .createInterpreterPanel(this, false);
+
+        // Let user activate manually
+        console.addFirstActivationCallback(() -> resetInterpreter());
+    });
+  }
+
   class PythonInteractiveTaskMonitor extends TaskMonitorAdapter {
 
     private PrintWriter output = null;

--- a/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
+++ b/src/main/java/ghidrathon/interpreter/GhidrathonInterpreter.java
@@ -632,6 +632,11 @@ public class GhidrathonInterpreter {
 
     } catch (JepException e) {
 
+      // Check for custom Python-side exception `InterpreterExit`
+      if (e.getMessage() != null && e.getMessage().contains("InterpreterExit")) {
+        throw new ghidrathon.GhidrathonInterpreterExitException();  // Throw signal Java-side
+      }
+
       // Python exceptions should be handled in Python land; something bad must have happened
       e.printStackTrace(this.err);
       throw new RuntimeException(e);


### PR DESCRIPTION
Resolves #33


Key changes:
1. Introduced a cunstom `InterpreterExit` exception in Python to signal interpreter termination
2. Mapped `InterpreterExit` to a Java-side exception `GhidrathonInterpreterExitException` to break out of the interpreter input thread
3. Gracefully shut down interpreter components (`inputThread`, `console`, `interactiveScript`, and `interactiveTaskMonitor`) when `sys.exit()` is called
4. Re-registered a fresh interpreter panel via `InterpreterPanelService` to ensure Ghidrathon remains available in the Ghidra’s menu after exit and let the user activate it manually later


Note: Clicking the close [X] button in the interpreter window only hides it (Ghidra's standard dockable panel behavior(?)). However, calling sys.exit() now performs a full shutdown and re-registration of the console